### PR TITLE
Upgrade build script for distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 sourceCompatibility = JavaVersion.VERSION_12
 targetCompatibility = JavaVersion.VERSION_12
 tasks.withType(JavaCompile).each {
-    it.options.compilerArgs.add('--enable-preview')     // to support Java 12 new switch construction
+    it.options.compilerArgs.add('--enable-preview')     // to support Java new language features
 }
 
 bootJar {
@@ -36,7 +36,7 @@ bootJar {
     manifest {
         attributes(
                 "Implementation-Title": "AnaLog",
-                "Implementation-Version": version,
+                "Implementation-Version": archiveVersion,
                 "Implementation-Vendor": "Toparvion"
         )
     }
@@ -97,8 +97,28 @@ test {
     useJUnitPlatform()
     jvmArgs(['--enable-preview'])
 }
-startScripts {
-    enabled = false
+
+startScripts { enabled = false }        // to avoid build fails because of Gradle application plugin 
+
+distributions {
+    boot {
+        contents {
+            into 'config/', { from 'config/' }
+            into 'tail-win', { from 'tail/win' }
+            into('') {   // add empty dirs for logs and work files as per https://stackoverflow.com/a/48901794/3507435
+                File.createTempDir().with {
+                    def tmpLog = new File(absolutePath, 'log')
+                    tmpLog.mkdirs()
+                    from(absolutePath) { includeEmptyDirs = true }
+                }
+                File.createTempDir().with {
+                    def tmpLog = new File(absolutePath, 'work')
+                    tmpLog.mkdirs()
+                    from(absolutePath) { includeEmptyDirs = true }
+                }
+            }
+        }
+    }
 }
 
 //<editor-fold desc="Tasks for working with Docker images">

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!--<editor-fold desc="File appender">-->
+    <property name="FILE_LOG_PATTERN"
+              value="%d{ISO8601} ${LOG_LEVEL_PATTERN:-%5p} [%t] - %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>log/analog.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- daily rollover. Make sure the path matches the one in the file element or else
+             the rollover logs are placed in the working directory. -->
+            <fileNamePattern>log/analog_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <!--</editor-fold>-->
+
+    <!--<editor-fold desc="Console appender">-->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(%15.15t){faint} - %clr(%-40.40logger{39}){cyan} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <!--</editor-fold>-->
+
+    <!-- Default (root) log level and appender -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+    <!-- =============================== Application loggers (from business logic) ============================== -->
+    <logger name="tech.toparvion.analog" level="TRACE"/>
+    <logger name="tech.toparvion.analog.remote.server.RecordSender" level="DEBUG"/>
+    <logger name="tech.toparvion.analog.util.dev.LogFileGenerator" level="INFO"/>
+    <!-- ===================================== System loggers (from libraries) ================================== -->
+    <logger name="org.springframework.integration.file.tail.OSDelegatingFileTailingMessageProducer" level="DEBUG"/>
+
+</configuration>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
This is the first step in automating of generation of ready-to-use startup scripts for AnaLog. Currently these scripts require some manual preparations before including into final distribution. It is desired to have single Gradle task that would be able to generate fully prepared zip and tar.gz distributions.

So far, the following steps still need to be automated for startup scripts:

- changing current work dir to `APP_HOME`
- exposing `APP_NAME` environment variable to the JVM process
- adding `tail-win` directory to `PATH` environment variable (Windows only)