### PR TITLE
Fix popups disappearing

### DIFF
--- a/src/main/java/tech/toparvion/analog/model/config/entry/LogType.java
+++ b/src/main/java/tech/toparvion/analog/model/config/entry/LogType.java
@@ -36,7 +36,8 @@ public enum LogType {
   }
 
   /**
-   * Checks if given log path is of current log type, e.g. {@code docker://my-container} is of type {@link #DOCKER}.<br/>
+   * Checks if given log path is of current log type, e.g. whether {@code docker://my-container} is
+   * of type {@link #DOCKER}.<br/>
    * The checking takes aliases in count therefore both {@link #KUBERNETES} and {@link #K8S} types match
    * path {@code k8s://my-deploy/my-pod}.<br/>
    * The checking is case <em>in</em>sensitive.

--- a/src/main/java/tech/toparvion/analog/remote/agent/TailEventHandler.java
+++ b/src/main/java/tech/toparvion/analog/remote/agent/TailEventHandler.java
@@ -26,6 +26,7 @@ import static tech.toparvion.analog.remote.agent.AgentConstants.*;
 import static tech.toparvion.analog.remote.agent.AgentUtils.composeTrackingFlowId;
 import static tech.toparvion.analog.remote.agent.AgentUtils.extractOutChannel;
 import static tech.toparvion.analog.util.AnaLogUtils.doSafely;
+import static tech.toparvion.analog.util.PathUtils.convertToUnixStyle;
 
 /**
  * @author Toparvion
@@ -58,9 +59,7 @@ public class TailEventHandler {
   @EventListener
   public void processFileTailingEvent(FileTailingEvent tailingEvent) {
     log.debug("received-tailing-event", tailingEvent.toString());
-    String sourceString = tailingEvent.getSource().toString();
-    // sourceString is tracking flow component name e.g. tailProcess_k8s://namespace/fee/deployment/backend
-    String logPath = sourceString.substring(TAIL_PROCESS_ADAPTER_PREFIX.length());
+    String logPath = convertToUnixStyle(tailingEvent.getFile().getPath());
 
     // in case of log appearing we must additionally check its path against access restrictions as the log may be 
     // a symlink to some real file that in turn is located in denied location

--- a/src/main/java/tech/toparvion/analog/remote/agent/TailEventHandler.java
+++ b/src/main/java/tech/toparvion/analog/remote/agent/TailEventHandler.java
@@ -59,7 +59,7 @@ public class TailEventHandler {
   @EventListener
   public void processFileTailingEvent(FileTailingEvent tailingEvent) {
     log.debug("received-tailing-event", tailingEvent.toString());
-    String logPath = convertToUnixStyle(tailingEvent.getFile().getPath());
+    String logPath = convertToUnixStyle(tailingEvent.getFile().getAbsolutePath());    // see ContainerTargetFile
 
     // in case of log appearing we must additionally check its path against access restrictions as the log may be 
     // a symlink to some real file that in turn is located in denied location

--- a/src/main/java/tech/toparvion/analog/remote/agent/si/ContainerTargetFile.java
+++ b/src/main/java/tech/toparvion/analog/remote/agent/si/ContainerTargetFile.java
@@ -1,23 +1,41 @@
 package tech.toparvion.analog.remote.agent.si;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
  * @author Toparvion
  * @since v0.11
  */
-@SuppressWarnings("NullableProblems")
 public class ContainerTargetFile extends File {
   /**
    * The prefix including {@value tech.toparvion.analog.util.PathUtils#CUSTOM_SCHEMA_SEPARATOR} separator.
    */
   private final String fullPrefix;
+  /**
+   * The target resource for tailing, e.g. {@code pod/myapp-666568ff7f-zmf88}
+   */
   private final String target;
+  /**
+   * The full log path as it came from the client. May differ from the {@code fullPrefix+target} combination in case 
+   * of complicated Kubernetes targets. For example, if the original log path was specified as<br/>   
+   * {@code k8s://namespace/upc/pod/myapp-666568ff7f-zmf88} <br/>
+   * then the target will be just <br/>
+   * {@code pod/myapp-666568ff7f-zmf88}.
+   */
+  @Nullable
+  private final String originalLogPath;
 
-  public ContainerTargetFile(String fullPrefix, String target) {
+  public ContainerTargetFile(String fullPrefix, String target, @Nullable String originalLogPath) {
     super("");
     this.fullPrefix = fullPrefix;
     this.target = target;
+    this.originalLogPath = originalLogPath;
+  }
+
+  public ContainerTargetFile(String fullPrefix, String target) {
+    this(fullPrefix, target, null);
   }
 
   /**
@@ -25,6 +43,7 @@ public class ContainerTargetFile extends File {
    * {@code my-container} for Docker
    * @return target resource (same as {@link #getCanonicalPath()})
    */
+  @Nonnull
   @Override
   public String getName() {
     return target;
@@ -35,13 +54,17 @@ public class ContainerTargetFile extends File {
    * for example {@code deploy/my-deployment} for K8s or {@code my-container} for Docker
    * @return target resource (same as {@link #getName()})
    */
+  @Nonnull
   @Override
   public String getCanonicalPath() {
     return target;
   }
 
+  @Nonnull
   @Override
   public String getAbsolutePath() {
-    return fullPrefix + target;
+    return (originalLogPath != null)
+            ? originalLogPath
+            : (fullPrefix + target);
   }
 }

--- a/src/main/java/tech/toparvion/analog/remote/agent/si/ProcessTailMessageProducer.java
+++ b/src/main/java/tech/toparvion/analog/remote/agent/si/ProcessTailMessageProducer.java
@@ -28,9 +28,11 @@ import java.util.Date;
 import static java.lang.String.format;
 
 /**
+ * <code><pre>
  * sudo docker logs --follow --tail=0 b181bbb05d49
  * kubectl logs --follow --tail=1 deployment/devrel-restorun
  * kubectl logs --follow --tail=1 devrel-restorun-cbfc8b84f-fch4h
+ * </pre></code>
  *
  * @author Gary Russell
  * @author Gavin Gray

--- a/src/main/java/tech/toparvion/analog/remote/agent/tailing/TailingFlowProvider.java
+++ b/src/main/java/tech/toparvion/analog/remote/agent/tailing/TailingFlowProvider.java
@@ -309,7 +309,7 @@ public class TailingFlowProvider {
     var fullPrefix = logPath.getType().getPrefix() + CUSTOM_SCHEMA_SEPARATOR;
     return new ProcessTailAdapterSpec()
         .executable(adapterParams.getExecutable())
-        .file(new ContainerTargetFile(fullPrefix, resource))
+        .file(new ContainerTargetFile(fullPrefix, resource, logPath.getFullPath()))
         .id(adapterId)
         .nativeOptions(k8sLogsOptions)
         .fileDelay(trackingProperties.getRetryDelay().toMillis())

--- a/src/main/java/tech/toparvion/analog/remote/websocket/WebSocketEventListener.java
+++ b/src/main/java/tech/toparvion/analog/remote/websocket/WebSocketEventListener.java
@@ -193,7 +193,7 @@ public class WebSocketEventListener {
    * to watch arbitrary plain logs independently of its configuration. Particularly, it means that a user can set any
    * path into AnaLog's address line and start to watch it the same way as if it was pre-configured as a choice
    * variant in configuration file.
-   * <p>This logic doesn't apply to composite logs (yet), but it would be great to implement it.
+   * <p>This logic doesn't apply to composite logs (yet), but it would be great to implement it someday.
    *
    * @param path full path of log file to watch for
    * @return newly created log config entry for the specified path

--- a/src/main/java/tech/toparvion/analog/util/LocalizedLogger.java
+++ b/src/main/java/tech/toparvion/analog/util/LocalizedLogger.java
@@ -21,11 +21,11 @@ public class LocalizedLogger {
   }
 
   public void trace(String key, Object... args) {
-    log.info(resolveTemplate(key), args);
+    log.trace(resolveTemplate(key), args);
   }
 
   public void debug(String key, Object... args) {
-    log.info(resolveTemplate(key), args);
+    log.debug(resolveTemplate(key), args);
   }
 
   public void info(String key, Object... args) {
@@ -33,11 +33,11 @@ public class LocalizedLogger {
   }
 
   public void warn(String key, Object... args) {
-    log.info(resolveTemplate(key), args);
+    log.warn(resolveTemplate(key), args);
   }
 
   public void error(String key, Object... args) {
-    log.info(resolveTemplate(key), args);
+    log.error(resolveTemplate(key), args);
   }
 
 }

--- a/src/test/java/tech/toparvion/analog/remote/agent/TailEventHandlerTest.java
+++ b/src/test/java/tech/toparvion/analog/remote/agent/TailEventHandlerTest.java
@@ -1,0 +1,183 @@
+package tech.toparvion.analog.remote.agent;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.context.MessageSource;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.dsl.StandardIntegrationFlow;
+import org.springframework.integration.dsl.context.IntegrationFlowContext;
+import org.springframework.integration.dsl.context.IntegrationFlowContext.IntegrationFlowRegistration;
+import org.springframework.integration.file.tail.FileTailingMessageProducerSupport.FileTailingEvent;
+import org.springframework.messaging.Message;
+import tech.toparvion.analog.model.remote.AccessViolationTailingEvent;
+import tech.toparvion.analog.remote.agent.origin.restrict.FileAccessGuard;
+import tech.toparvion.analog.service.origin.LogEventTypeDetector;
+
+import java.io.File;
+import java.security.AccessControlException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static tech.toparvion.analog.model.LogEventType.LOG_NOT_FOUND;
+import static tech.toparvion.analog.model.LogEventType.LOG_ROTATED;
+import static tech.toparvion.analog.remote.agent.AgentConstants.*;
+import static tech.toparvion.analog.remote.agent.AgentUtils.composeTrackingFlowId;
+import static tech.toparvion.analog.util.PathUtils.convertToUnixStyle;
+
+/**
+ * @author Toparvion
+ * @since v0.14
+ */
+class TailEventHandlerTest {
+
+  @Mock IntegrationFlowContext flowContextMock;
+  @Mock LogEventTypeDetector logTypeEventDetectorMock;
+  @Mock FileAccessGuard fileAccessGuardMock;
+  @Mock MessageSource messageSourceMock;
+
+  TailEventHandler sut;
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this);
+    sut = new TailEventHandler(flowContextMock, logTypeEventDetectorMock,
+        fileAccessGuardMock, messageSourceMock);
+  }
+
+  @Test
+  @DisplayName("Tailing event is sent to the clients and contains the data for UI message")
+  void normalExecution() {
+    // given
+    var logFileName = "app.log";
+    var logFile = new File(logFileName);
+    String logPath = convertToUnixStyle(logFile.getAbsolutePath());
+    var tailingFlowId = TAIL_FLOW_PREFIX + logPath;
+    var trackingFlowId = composeTrackingFlowId(FLAT_PREFIX, logPath);
+    var eventSource = new Object();
+    var messageText = "file not found";
+    var event = new FileTailingEvent(eventSource, messageText, logFile);
+
+    when(logTypeEventDetectorMock.detectEventType(event)).thenReturn(LOG_NOT_FOUND);
+
+    when(flowContextMock.getRegistrationById(tailingFlowId))
+        .thenReturn(mock(IntegrationFlowRegistration.class));
+    var flatTrackingFlowRegMock = mock(IntegrationFlowRegistration.class);
+    when(flowContextMock.getRegistrationById(trackingFlowId))
+        .thenReturn(flatTrackingFlowRegMock);
+    var trackingFlowMock = mock(StandardIntegrationFlow.class);
+    when(flatTrackingFlowRegMock.getIntegrationFlow())
+        .thenReturn(trackingFlowMock);
+    var trackingFlowOutChannel = mock(PublishSubscribeChannel.class);
+    when(trackingFlowMock.getIntegrationComponents())
+        .thenReturn(Map.of(trackingFlowOutChannel, ""));
+
+    // when
+    sut.processFileTailingEvent(event);
+
+    // then
+    verify(logTypeEventDetectorMock).detectEventType(event);
+    verifyNoInteractions(fileAccessGuardMock);
+    verify(flowContextMock, never()).remove(tailingFlowId);
+
+    verify(flowContextMock).getRegistrationById(trackingFlowId);
+    verify(flatTrackingFlowRegMock).getIntegrationFlow();
+    verify(trackingFlowMock).getIntegrationComponents();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Message<?>> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(trackingFlowOutChannel).send(messageCaptor.capture());
+
+    Message<?> message = messageCaptor.getValue();
+    assertTrue(message.getPayload() instanceof FileTailingEvent);
+    var fileTailingEvent = (FileTailingEvent) message.getPayload();
+    assertTrue(fileTailingEvent.toString().contains(messageText));
+    assertSame(logFile, fileTailingEvent.getFile());
+    assertSame(eventSource, fileTailingEvent.getSource());
+  }
+
+  @Test
+  @DisplayName("Access violation exception is sent to the clients")
+  void processEventWithAccessViolation() {
+    // given
+    var logFileName = "app.log";
+    var logFile = new File(logFileName);
+    String logPath = convertToUnixStyle(logFile.getAbsolutePath());
+    var tailingFlowId = TAIL_FLOW_PREFIX + logPath;
+    var trackingFlowId = composeTrackingFlowId(FLAT_PREFIX, logPath);
+    var eventSource = new Object();
+    var messageText = "file not found";
+    var event = new FileTailingEvent(eventSource, messageText, logFile);
+
+    when(logTypeEventDetectorMock.detectEventType(event)).thenReturn(LOG_ROTATED);
+    doThrow(AccessControlException.class).when(fileAccessGuardMock).checkAccess(logPath);
+    when(flowContextMock.getRegistrationById(tailingFlowId))
+        .thenReturn(mock(IntegrationFlowRegistration.class));
+    var flatTrackingFlowRegMock = mock(IntegrationFlowRegistration.class);
+    when(flowContextMock.getRegistrationById(trackingFlowId))
+        .thenReturn(flatTrackingFlowRegMock);
+    var trackingFlowMock = mock(StandardIntegrationFlow.class);
+    when(flatTrackingFlowRegMock.getIntegrationFlow())
+        .thenReturn(trackingFlowMock);
+    var trackingFlowOutChannel = mock(PublishSubscribeChannel.class);
+    when(trackingFlowMock.getIntegrationComponents())
+        .thenReturn(Map.of(trackingFlowOutChannel, ""));
+
+    // when
+    sut.processFileTailingEvent(event);
+
+    // then
+    verify(logTypeEventDetectorMock).detectEventType(event);
+    verify(fileAccessGuardMock).checkAccess(logPath);
+    verify(flowContextMock).getRegistrationById(tailingFlowId);
+    verify(flowContextMock).remove(tailingFlowId);
+
+    verify(flowContextMock).getRegistrationById(trackingFlowId);
+    verify(flatTrackingFlowRegMock).getIntegrationFlow();
+    verify(trackingFlowMock).getIntegrationComponents();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Message<?>> messageCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(trackingFlowOutChannel).send(messageCaptor.capture());
+
+    Message<?> message = messageCaptor.getValue();
+    assertTrue(message.getPayload() instanceof AccessViolationTailingEvent);
+    var accessViolationTailingEvent = (AccessViolationTailingEvent) message.getPayload();
+    assertTrue(accessViolationTailingEvent.toString().contains(messageText));
+    assertSame(logFile, accessViolationTailingEvent.getFile());
+    assertSame(eventSource, accessViolationTailingEvent.getSource());
+  }
+
+  @Test
+  @DisplayName("The exception is thrown when no tracking flow found")
+  void noTrackingFlowFound() {
+    // given
+    var logFileName = "app.log";
+    var logFile = new File(logFileName);
+    String logPath = convertToUnixStyle(logFile.getAbsolutePath());
+    var flatTrackingFlowId = composeTrackingFlowId(FLAT_PREFIX, logPath);
+    var groupTrackingFlowId = composeTrackingFlowId(GROUP_PREFIX, logPath);
+    var eventSource = new Object();
+    var messageText = "file not found";
+    var event = new FileTailingEvent(eventSource, messageText, logFile);
+
+    when(logTypeEventDetectorMock.detectEventType(event)).thenReturn(LOG_ROTATED);
+
+    // when
+    Executable sutAction = () -> sut.processFileTailingEvent(event);
+
+    // then
+    var exception = assertThrows(IllegalStateException.class, sutAction);
+    verify(logTypeEventDetectorMock).detectEventType(event);
+    verify(fileAccessGuardMock).checkAccess(logPath);
+
+    verify(flowContextMock).getRegistrationById(flatTrackingFlowId);
+    verify(flowContextMock).getRegistrationById(groupTrackingFlowId);
+    assertTrue(exception.getMessage().contains(event.toString()));
+  }
+}

--- a/src/test/java/tech/toparvion/analog/remote/agent/si/ContainerTargetFileTest.java
+++ b/src/test/java/tech/toparvion/analog/remote/agent/si/ContainerTargetFileTest.java
@@ -1,0 +1,49 @@
+package tech.toparvion.analog.remote.agent.si;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Toparvion
+ * @since v0.14
+ */
+class ContainerTargetFileTest {
+
+  private static final String K8S_FULL_PREFIX = "k8s://";
+  private static final String K8S_TARGET = "deploy/my-deploy";
+
+  @Test
+  @DisplayName("When originalPath isn't set, the absolutePath is 'prefix+target'")
+  void fullNameWithoutOriginalPath() {
+    var sut = new ContainerTargetFile(K8S_FULL_PREFIX, K8S_TARGET);
+    assertAll(
+        () -> assertEquals(K8S_TARGET, sut.getCanonicalPath()),
+        () -> assertEquals(K8S_TARGET, sut.getName()),
+        () -> assertEquals((K8S_FULL_PREFIX + K8S_TARGET), sut.getAbsolutePath())
+    );
+  }
+
+  @Test
+  @DisplayName("When originalPath is set, the absolutePath equals to it")
+  void fullNameWithOriginalPath() {
+    var originalPath = K8S_FULL_PREFIX + "namespace/test/" + K8S_TARGET;
+    var sut = new ContainerTargetFile(K8S_FULL_PREFIX, K8S_TARGET, originalPath);
+    assertAll(
+        () -> assertEquals(K8S_TARGET, sut.getCanonicalPath()),
+        () -> assertEquals(K8S_TARGET, sut.getName()),
+        () -> assertEquals(originalPath, sut.getAbsolutePath())
+    );
+  }
+
+  @Test
+  @DisplayName("Abstract pathName stays empty with any kind of constructor")
+  void actualPathIsEmpty() {
+    var sut1 = new ContainerTargetFile(K8S_FULL_PREFIX, K8S_TARGET);
+    var sut2 = new ContainerTargetFile(K8S_FULL_PREFIX, K8S_TARGET, "whatever");
+    assertEquals("", sut1.getPath());
+    assertEquals("", sut2.getPath());
+  }
+}


### PR DESCRIPTION
Fixes #26 .

Changes summary:
- Do not rely on the result of endpoints' `toString()` method anymore
- Instead, use `ContainerTargetFile` as the provider of information about event source
- Fix log levels in `LocalizedLogger`